### PR TITLE
feat(roi): add interactive roi selection with slop and opencv, and capture roi

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,11 @@ from x11_interactor import X11WindowInteractor
 from Xlib import XK
 import time
 import numpy as np
+# Optional: Import cv2 if you want to display images captured or used for ROI selection
+try:
+    import cv2
+except ImportError:
+    cv2 = None
 
 def benchmark_capture(interactor, num_frames=100):
     """
@@ -43,11 +48,63 @@ def main():
     interactor.activate()
     print("Cursor relative to window:", coordinates)
     interactor.click(coordinates[0], coordinates[1])
-    time.sleep(5)
+    time.sleep(1) # Reduced sleep time
     interactor.send_key('1')
-    time.sleep(2)
+    time.sleep(1) # Reduced sleep time
+
+    # --- Example for select_roi_interactive (requires 'slop') ---
+    print("\nAttempting ROI selection using 'slop'...")
+    roi_slop = interactor.select_roi_interactive()
+    if roi_slop:
+        print(f"ROI selected via slop: {roi_slop}")
+        # Example: Capture the selected ROI
+        img_roi_slop = interactor.capture(xywh=roi_slop)
+        print(f"Captured slop ROI shape: {img_roi_slop.shape}")
+        # Optional: Display with OpenCV
+        if cv2:
+            try:
+                cv2.imshow("Slop ROI Capture", cv2.cvtColor(img_roi_slop, cv2.COLOR_BGRA2BGR))
+                cv2.waitKey(2000) # Display for 2 seconds
+                cv2.destroyWindow("Slop ROI Capture")
+            except Exception as e:
+                print(f"Could not display slop ROI image with OpenCV: {e}")
+    else:
+        print("ROI selection with slop failed or was cancelled.")
+
+    time.sleep(1)
+
+    # --- Example for select_roi_interactive_cv (requires 'opencv-python') ---
+    print("\nAttempting ROI selection using OpenCV...")
+    # You can optionally pass a pre-captured image:
+    # initial_capture = interactor.capture()
+    # roi_cv = interactor.select_roi_interactive_cv(image=initial_capture)
+    # Or let it capture internally:
+    roi_cv = interactor.select_roi_interactive_cv()
+    if roi_cv:
+        print(f"ROI selected via OpenCV: {roi_cv}")
+        # Example: Capture the selected ROI
+        img_roi_cv = interactor.capture(xywh=roi_cv)
+        print(f"Captured OpenCV ROI shape: {img_roi_cv.shape}")
+        # Optional: Display with OpenCV
+        if cv2:
+            try:
+                cv2.imshow("OpenCV ROI Capture", cv2.cvtColor(img_roi_cv, cv2.COLOR_BGRA2BGR))
+                cv2.waitKey(2000) # Display for 2 seconds
+                cv2.destroyWindow("OpenCV ROI Capture")
+            except Exception as e:
+                print(f"Could not display OpenCV ROI image with OpenCV: {e}")
+    else:
+        print("ROI selection with OpenCV failed or was cancelled.")
+
+    time.sleep(1)
+
     # Run benchmark
     benchmark_capture(interactor)
+
+    # Stop the background updater before exiting
+    print("\nStopping background updater...")
+    interactor.stop()
+    print("Interactor stopped.")
 
 if __name__ == "__main__":
     main()

--- a/x11_interactor.py
+++ b/x11_interactor.py
@@ -417,7 +417,7 @@ class X11WindowInteractor:
                 h = max(1, y2 - y1)
                 param['roi'] = (x1, y1, w, h)
 
-        cv2.namedWindow(window_name)
+        cv2.namedWindow(window_name, cv2.WINDOW_NORMAL)
         cv2.setMouseCallback(window_name, mouse_callback, roi_data)
 
         print("Select ROI in the OpenCV window. Press ENTER to confirm, ESC to cancel.")

--- a/x11_interactor.py
+++ b/x11_interactor.py
@@ -9,6 +9,10 @@ import time
 import random
 import mss
 import threading
+try:
+    import cv2
+except ImportError:
+    cv2 = None  # Handle case where OpenCV is not installed
 
 
 class X11WindowInteractor:
@@ -63,7 +67,7 @@ class X11WindowInteractor:
     def update(self):
         # Update the stored window information
         self.window_info = self.get_window_info()
-    
+
     def _background_updater(self):
         # Background thread to periodically update window info
         while not self._stop_updater.is_set():
@@ -252,3 +256,202 @@ class X11WindowInteractor:
         # Use mss to grab the screen region and convert it to a numpy array
         img_array = np.array(self.sct.grab({'left': x, 'top': y, 'width': w, 'height': h}))
         return img_array
+
+    def select_roi_interactive(self) -> tuple[int, int, int, int] | None:
+        """
+        Allows the user to interactively select a rectangular region of interest (ROI)
+        within the target window using the external 'slop' utility.
+
+        Requires 'slop' to be installed on the system (e.g., sudo apt install slop).
+
+        Returns:
+            A tuple (x, y, width, height) representing the selected ROI relative
+            to the window's top-left corner, or None if the selection was cancelled,
+            failed, or did not overlap with the window.
+        """
+        # Ensure window info is reasonably up-to-date
+        self.update()
+        win_x = self.window_info.get('x')
+        win_y = self.window_info.get('y')
+        win_w = self.window_info.get('width')
+        win_h = self.window_info.get('height')
+
+        if None in [win_x, win_y, win_w, win_h]:
+            print("Error: Could not retrieve valid window geometry.")
+            return None
+
+        print("Drag the mouse to select a rectangular region...")
+        try:
+            # Run slop to capture selection geometry (absolute screen coordinates)
+            # -f specifies the output format: x y width height
+            result = subprocess.run(
+                ['slop', '-f', '%x %y %w %h'],
+                capture_output=True,
+                text=True,
+                check=True  # Raise exception on non-zero exit code (e.g., user cancel)
+            )
+            output = result.stdout.strip()
+            if not output:
+                print("Selection cancelled or failed (empty output).")
+                return None
+
+            sel_x_abs, sel_y_abs, sel_w, sel_h = map(int, output.split())
+
+        except FileNotFoundError:
+            print("Error: 'slop' command not found. Please install it (e.g., 'sudo apt install slop').")
+            return None
+        except subprocess.CalledProcessError:
+            # Likely occurred if the user cancelled the selection (e.g., Esc key)
+            print("Selection cancelled or failed (slop exited abnormally).")
+            return None
+        except Exception as e:
+            print(f"An unexpected error occurred while running slop: {e}")
+            return None
+
+        # Convert absolute screen coordinates to window-relative coordinates
+        rel_x = sel_x_abs - win_x
+        rel_y = sel_y_abs - win_y
+
+        # --- Clamp the selection to the window boundaries ---
+        # Find the intersection rectangle between the selection and the window
+        intersect_x1 = max(rel_x, 0)
+        intersect_y1 = max(rel_y, 0)
+        intersect_x2 = min(rel_x + sel_w, win_w)
+        intersect_y2 = min(rel_y + sel_h, win_h)
+
+        # Calculate the width and height of the intersection
+        final_w = intersect_x2 - intersect_x1
+        final_h = intersect_y2 - intersect_y1
+
+        # If the intersection has no area, the selection was outside the window
+        if final_w <= 0 or final_h <= 0:
+            print("Selected region is outside the target window.")
+            return None
+
+        # The top-left corner of the final ROI is the top-left of the intersection
+        final_x = intersect_x1
+        final_y = intersect_y1
+
+        print(f"Selected ROI (relative to window): x={final_x}, y={final_y}, w={final_w}, h={final_h}")
+        return (final_x, final_y, final_w, final_h)
+
+    def select_roi_interactive_cv(self, image: np.ndarray = None) -> tuple[int, int, int, int] | None:
+        """
+        Allows the user to interactively select a rectangular ROI using OpenCV.
+        Displays the current window content (or a provided image) and lets the user
+        draw a rectangle.
+
+        Requires 'opencv-python' to be installed (`pip install opencv-python`).
+
+        Parameters:
+            image (np.ndarray, optional): A pre-captured image (NumPy array) to use
+                                          for selection instead of capturing a new one.
+                                          Should be in a format OpenCV can handle (e.g., BGR, BGRA).
+                                          Defaults to None, which triggers a new capture.
+
+        Returns:
+            A tuple (x, y, width, height) relative to the top-left corner of the
+            displayed image/window content, or None if OpenCV is not installed,
+            capture fails, or selection is cancelled.
+        """
+        if cv2 is None:
+            print("Error: OpenCV (cv2) is not installed. Cannot use this method.")
+            print("Try installing it: pip install opencv-python")
+            return None
+
+        img_bgr = None
+        if image is None:
+            # Capture the current state of the window if no image provided
+            print("Capturing window content...")
+            img_capture = self.capture()
+            if img_capture is None or img_capture.size == 0:
+                print("Error: Failed to capture window content for OpenCV selection.")
+                return None
+            # MSS captures in BGRA, OpenCV typically uses BGR
+            img_bgr = cv2.cvtColor(img_capture, cv2.COLOR_BGRA2BGR)
+        else:
+            # Use the provided image
+            print("Using provided image...")
+            if image.ndim == 3 and image.shape[2] == 4:  # Check if it's likely BGRA or RGBA
+                # Convert RGBA/BGRA to BGR if necessary
+                img_bgr = cv2.cvtColor(image, cv2.COLOR_BGRA2BGR)  # Or COLOR_RGBA2BGR if input is RGBA
+            elif image.ndim == 3 and image.shape[2] == 3:  # Assume BGR or RGB
+                img_bgr = image  # Assume it's already BGR or compatible
+            elif image.ndim == 2:  # Grayscale
+                img_bgr = cv2.cvtColor(image, cv2.COLOR_GRAY2BGR)
+            else:
+                print("Error: Provided image has unsupported format/dimensions.")
+                return None
+
+        if img_bgr is None or img_bgr.size == 0:
+            print("Error: Image processing failed.")
+            return None
+
+        # Dictionary to store mouse callback state
+        roi_data = {'drawing': False, 'start_point': None, 'end_point': None, 'roi': None}
+        window_name = "Select ROI - Drag Mouse | ENTER: Confirm | ESC: Cancel"
+
+        def mouse_callback(event, x, y, flags, param):
+            # Clamp coordinates coming from OpenCV window to image bounds
+            x = max(0, min(x, img_bgr.shape[1] - 1))
+            y = max(0, min(y, img_bgr.shape[0] - 1))
+
+            if event == cv2.EVENT_LBUTTONDOWN:
+                param['drawing'] = True
+                param['start_point'] = (x, y)
+                param['end_point'] = (x, y)  # Initialize end point
+                param['roi'] = None  # Reset final ROI on new click
+            elif event == cv2.EVENT_MOUSEMOVE:
+                if param['drawing']:
+                    param['end_point'] = (x, y)
+            elif event == cv2.EVENT_LBUTTONUP:
+                param['drawing'] = False
+                param['end_point'] = (x, y)
+                # Calculate final ROI (ensure x1 < x2, y1 < y2)
+                x1 = min(param['start_point'][0], param['end_point'][0])
+                y1 = min(param['start_point'][1], param['end_point'][1])
+                x2 = max(param['start_point'][0], param['end_point'][0])
+                y2 = max(param['start_point'][1], param['end_point'][1])
+                # Ensure width/height are at least 1 if start/end are same point click
+                w = max(1, x2 - x1)
+                h = max(1, y2 - y1)
+                param['roi'] = (x1, y1, w, h)
+
+        cv2.namedWindow(window_name)
+        cv2.setMouseCallback(window_name, mouse_callback, roi_data)
+
+        print("Select ROI in the OpenCV window. Press ENTER to confirm, ESC to cancel.")
+
+        while True:
+            display_img = img_bgr.copy()  # Draw on a copy
+            start = roi_data['start_point']
+            end = roi_data['end_point']
+
+            # Draw rectangle: green while drawing, red when finalized
+            if start and end:
+                if roi_data['drawing']:
+                    cv2.rectangle(display_img, start, end, (0, 255, 0), 1)  # Green
+                elif roi_data['roi']:
+                    x, y, w, h = roi_data['roi']
+                    cv2.rectangle(display_img, (x, y), (x + w, y + h), (0, 0, 255), 2)  # Red (thicker)
+
+            cv2.imshow(window_name, display_img)
+            key = cv2.waitKey(20) & 0xFF
+
+            if key == 27:  # ESC key
+                print("Selection cancelled.")
+                roi_data['roi'] = None
+                break
+            elif key == 13:  # Enter key
+                if roi_data['roi']:
+                    print(f"Selected ROI: {roi_data['roi']}")
+                    break
+                else:
+                    print("No ROI selected. Please drag the mouse to select.")
+
+        cv2.destroyAllWindows()
+        # Force closing any potential lingering windows
+        for i in range(5):
+            cv2.waitKey(1)
+
+        return roi_data['roi']


### PR DESCRIPTION
## Feature: Interactive Region of Interest (ROI) Selection

This pull request introduces interactive ROI selection, enhancing the `X11WindowInteractor` class with two new methods: `select_roi_interactive()` using `slop` and `select_roi_interactive_cv()` using OpenCV.  This allows users to define a rectangular area within a target window, which is crucial for targeted screen captures and automation tasks.

**Key Changes:**

*   **New Methods:**
    *   `select_roi_interactive()`: Selects ROI using the `slop` command-line utility. Requires `slop` to be installed.  Returns a tuple `(x, y, width, height)` representing the ROI relative to the window or `None` if selection fails or is cancelled. Handles clamping the selected region to the window bounds.
    *   `select_roi_interactive_cv()`: Selects ROI using an OpenCV window.  Requires `opencv-python` to be installed. Captures the window or uses a provided image in an OpenCV window, allowing the user to draw the ROI.  Returns a tuple `(x, y, width, height)` or `None` if selection fails by OpenCV cancel key of `ESC`.

*   **Dependencies:**
    *   Added optional dependencies: `slop` (system utility) and `opencv-python`.
    *   Clear installation instructions for both dependencies in `README.md`.
    *   Graceful handling of missing `cv2` import using `try...except` blocks and a cv2 is None check.

*   **README Updates:**
    *   Added sections explaining how to use the new ROI selection methods, including code examples for both `slop` and OpenCV approaches.
    *   Updated dependency list with installation commands.
    *   Expanded the feature list and included a brief example for ROI selection.

*   **Example `main.py`:**
    *   Augmented to demonstrate both ROI selection examples.
    *   Added OpenCV display of the captured ROI for visual verification (optional, only runs if `cv2` is available).
    *   Includes `time.sleep` pauses to allow time for the UI.
    *   Example is now invoked with `uv run python main.py`

**Benefits:**

*   **Enhanced Automation:** Enables users to precisely define the capture region.
*   **Flexibility:** Provides two different methods for ROI selection, catering to different preferences and system configurations.
*   **Improved User Experience:** Offers an interactive way to select regions of interest.
*   **Targeted Capture:** Supports capturing only the essential parts of the screen, improving performance and reducing data size.

**Testing:**

*   The new methods have been tested on a Linux system.
*   The example script (`main.py`) demonstrates the functionality of each method.
*   The ROI selection routines return `None` or the region tuple on success/failure.

**Considerations:**

*   The `slop` method relies on an external command-line utility (`slop`) which must be installed separately. The updated `README.md` contains installation recommendations for `slop`.
*   The OpenCV method requires `opencv-python` library. `README.md` contains install recommendation for it.
*   Error handling is in place to gracefully manage cases where `slop` or OpenCV is not installed and if the ROI methods error.
*   Clamping of the `slop` selected region to a target window is now implemented directly within the `select_roi_interactive()` function.

**Example Usage (from README.md):**

```python
# Using slop
roi_tuple = interactor.select_roi_interactive()
if roi_tuple:
  x, y, w, h = roi_tuple
  roi_capture = interactor.capture(xywh=roi_tuple)

# Using OpenCV
roi_tuple_cv = interactor.select_roi_interactive_cv()
if roi_tuple_cv:
  x, y, w, h = roi_tuple_cv
  roi_capture_cv = interactor.capture(xywh=roi_tuple_cv)
```

**Impact:**

These changes significantly enhance the usability of `x11_interactor`, providing developers with robust and flexible tools for GUI automation and screen capture in X environments that do not require precise static coordinates.