### PR TITLE
fix: ensure mouse motion immediately precedes button press

### DIFF
--- a/x11_interactor.py
+++ b/x11_interactor.py
@@ -122,10 +122,6 @@ class X11WindowInteractor:
             is_hint=0,
             detail=0
         )
-        self.window.send_event(motion, propagate=True)
-        self.display.sync()
-        time.sleep(random.uniform(0.05, 0.1))
-
         # Press and release events
         press = Xlib.protocol.event.ButtonPress(
             time=Xlib.X.CurrentTime,
@@ -153,9 +149,12 @@ class X11WindowInteractor:
             state=0,
             detail=button
         )
-        self.window.send_event(press, propagate=True)
+        
+        # Send the events in order
+        self.window.send_event(motion, propagate=True)
         self.display.sync()
-        time.sleep(random.uniform(0.05, 0.1))
+        self.window.send_event(press, propagate=True)
+        time.sleep(random.uniform(0.05, 0.1)) # Smal delay to simulate human-like interaction
         self.window.send_event(release, propagate=True)
         self.display.sync()
 

--- a/x11_interactor.py
+++ b/x11_interactor.py
@@ -154,7 +154,7 @@ class X11WindowInteractor:
         self.window.send_event(motion, propagate=True)
         self.display.sync()
         self.window.send_event(press, propagate=True)
-        time.sleep(random.uniform(0.05, 0.1)) # Smal delay to simulate human-like interaction
+        time.sleep(random.uniform(0.05, 0.1)) # Small delay to simulate human-like interaction
         self.window.send_event(release, propagate=True)
         self.display.sync()
 


### PR DESCRIPTION
### Overview
This Pull Request refactors the sequence of X11 events for simulating mouse clicks to improve realism and reliability. The changes ensure that the mouse cursor is positioned at the target coordinates immediately before the button press event is dispatched.

### Key Changes
- Reordered the event dispatch sequence within the mouse click simulation logic.
- The `motion` event (simulating mouse movement to the click location) is now sent directly before the `ButtonPress` event.
- Consolidated the `display.sync()` and `time.sleep()` calls to occur after the `motion` event and `ButtonPress` event respectively, ensuring proper synchronization and a human-like delay.

### Reasoning
The previous implementation sent the mouse motion event, then introduced a delay, and only then sent the button press event. This reordering ensures that the mouse cursor is visually at the target coordinates and the display is synchronized *before* the button press event is registered. This more accurately mimics how a human interacts with a GUI (move, then click), which can improve the reliability of simulated clicks, especially in applications that are sensitive to the precise timing and sequence of mouse events. The delay after the button press further enhances the human-like interaction.

### Testing Notes (Optional)
Verify that simulated mouse clicks continue to function correctly across various applications and that their behavior appears natural.